### PR TITLE
Require a lockfile for a successful run of the application.

### DIFF
--- a/src/appenv.py
+++ b/src/appenv.py
@@ -295,12 +295,9 @@ class AppEnv(object):
         #   for ones that are clean or rebuild if necessary
         os.chdir(self.base)
         if not os.path.exists('requirements.lock'):
-            print('Running unclean installation from requirements.txt')
-            env_dir = os.path.join(self.appenv_dir, 'unclean')
-            ensure_venv(env_dir)
-            print('Ensuring unclean install ...')
-            cmd('{env_dir}/bin/python -m pip install -r requirements.txt'
-                ' --upgrade'.format(env_dir=env_dir))
+            print('No requirements.lock found. Generate it using'
+                  ' ./appenv update-lockfile.')
+            sys.exit(67)
         else:
             hash_content = []
             requirements = open("requirements.lock", "rb").read()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,3 +1,4 @@
+import pytest
 import io
 import os.path
 import subprocess
@@ -50,3 +51,25 @@ def test_bootstrap_and_run_python_with_lockfile(workdir, monkeypatch):
     output = subprocess.check_output(
         './appenv python -c "print(1)"', shell=True)
     assert output == b"1\n"
+
+
+def test_bootstrap_and_run_without_lockfile(workdir, monkeypatch):
+    """It raises as error if no requirements.lock is present."""
+    monkeypatch.setattr("sys.stdin", io.StringIO("ducker\nducker==2.0.1\n\n"))
+
+    env = appenv.AppEnv(os.path.join(workdir, 'ducker'))
+
+    env.init()
+
+    os.chdir(os.path.join(workdir, "ducker"))
+    with open("ducker", "r") as f:
+        # Ensure we're called with the Python-interpreter-under-test.
+        script = "#!{}\n{}".format(sys.executable, f.read())
+    with open("ducker", "w") as f:
+        f.write(script)
+
+    with pytest.raises(subprocess.CalledProcessError) as err:
+        subprocess.check_output(["./ducker", "--help"])
+    assert err.value.output == (
+        b"No requirements.lock found. Generate it using"
+        b" ./appenv update-lockfile.\n")


### PR DESCRIPTION
This ensures repeatable builds form the start of the project.

This solves an issue in batou https://github.com/flyingcircusio/batou/issues/107