### PR TITLE
Introduce new command arg `prepare`

### DIFF
--- a/src/appenv.py
+++ b/src/appenv.py
@@ -255,7 +255,10 @@ class AppEnv(object):
         p = subparsers.add_parser(
             "update-lockfile", help="Update the lock file.")
         p.set_defaults(func=self.update_lockfile)
-
+        
+        p = subparsers.add_parser('prepare', help='Prepare the venv.')
+        p.set_defaults(func=self.prepare)
+        
         p = subparsers.add_parser("init", help="Create a new appenv project.")
         p.set_defaults(func=self.init)
 
@@ -280,7 +283,7 @@ class AppEnv(object):
             args.func(args, remaining)
 
     def run(self, command, argv):
-        self._prepare()
+        self.prepare()
         cmd = os.path.join(self.env_dir, 'bin', command)
         argv = [cmd] + argv
         os.environ['APPENV_BASEDIR'] = self.base
@@ -309,7 +312,7 @@ class AppEnv(object):
             hash_content = f.read()
         return hashlib.new("sha256", hash_content).hexdigest()
 
-    def _prepare(self):
+    def prepare(self, args=None, remaining=None):
         # copy used requirements.txt into the target directory so we can use
         # that to check later
         # - when to clean up old versions? keep like one or two old revisions?


### PR DESCRIPTION
This allows preparing the venv before running the app for the first time.

It allows installing the packages in a seperate layer (for better caching) when using AppEnv inside docker.