### PR TITLE
actions: pin ubuntu version since ubuntu-22.04 doesn't include python 3.6 anymore

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: [ '3.6', '3.7', '3.8', '3.9' ]
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/tests/test_update_lockfile.py
+++ b/tests/test_update_lockfile.py
@@ -51,9 +51,12 @@ def test_update_lockfile_minimal_python(workdir, monkeypatch):
     assert os.path.exists(lockfile)
     with open(lockfile) as f:
         lockfile_content = f.read()
+    # replace underscore with dashes for python 3.6 testing
+    # some versions do not normalize the name like newer python versions
+    lockfile_content = lockfile_content.replace("_", "-")
     assert "pytest==6.1.2" in lockfile_content
     assert "importlib-metadata==" in lockfile_content
-    assert "typing_extensions==" in lockfile_content
+    assert "typing-extensions==" in lockfile_content
 
 
 @pytest.mark.skipif(

--- a/tests/test_update_lockfile.py
+++ b/tests/test_update_lockfile.py
@@ -53,7 +53,7 @@ def test_update_lockfile_minimal_python(workdir, monkeypatch):
         lockfile_content = f.read()
     assert "pytest==6.1.2" in lockfile_content
     assert "importlib-metadata==" in lockfile_content
-    assert "typing-extensions==" in lockfile_content
+    assert "typing_extensions==" in lockfile_content
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
See https://github.com/flyingcircusio/batou/pull/344 for similiar