### PR TITLE
Introduce new command arg `prepare`. (second attempt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ AppEnv itself is tested against Python 3.6+.
 
 ```
 $ ./appenv --help
-usage: appenv [-h] {update-lockfile,init,reset,python,run} ...
+usage: appenv [-h] {update-lockfile,init,reset,prepare,python,run} ...
 
 positional arguments:
-  {update-lockfile,init,reset,python,run}
+  {update-lockfile,init,reset,prepare,python,run}
     update-lockfile     Update the lock file.
     init                Create a new appenv project.
     reset               Reset the environment.
+    prepare             Prepare the venv.
     python              Spawn the embedded Python interpreter REPL
     run                 Run a script from the bin/ directory of the virtual env.
 

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -262,6 +262,9 @@ class AppEnv(object):
         p = subparsers.add_parser("reset", help="Reset the environment.")
         p.set_defaults(func=self.reset)
 
+        p = subparsers.add_parser('prepare', help='Prepare the venv.')
+        p.set_defaults(func=self.prepare)
+
         p = subparsers.add_parser(
             "python", help="Spawn the embedded Python interpreter REPL")
         p.set_defaults(func=self.python)
@@ -280,7 +283,7 @@ class AppEnv(object):
             args.func(args, remaining)
 
     def run(self, command, argv):
-        self._prepare()
+        self.prepare()
         cmd = os.path.join(self.env_dir, 'bin', command)
         argv = [cmd] + argv
         os.environ['APPENV_BASEDIR'] = self.base
@@ -309,7 +312,7 @@ class AppEnv(object):
             hash_content = f.read()
         return hashlib.new("sha256", hash_content).hexdigest()
 
-    def _prepare(self):
+    def prepare(self, args=None, remaining=None):
         # copy used requirements.txt into the target directory so we can use
         # that to check later
         # - when to clean up old versions? keep like one or two old revisions?

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -323,10 +323,12 @@ class AppEnv(object):
         self._assert_requirements_lock()
 
         hash_content = []
-        requirements = open("requirements.lock", "rb").read()
+        with open("requirements.lock", "rb") as f:
+            requirements = f.read()
         hash_content.append(os.fsencode(os.path.realpath(sys.executable)))
         hash_content.append(requirements)
-        hash_content.append(open(__file__, "rb").read())
+        with open(__file__, "rb") as f:
+            hash_content.append(f.read())
         env_hash = hashlib.new("sha256",
                                b"".join(hash_content)).hexdigest()[:8]
         env_dir = os.path.join(self.appenv_dir, env_hash)

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,0 +1,15 @@
+import os
+import appenv
+import io
+
+
+def test_prepare_creates_envdir(workdir, monkeypatch):
+    monkeypatch.setattr('sys.stdin', io.StringIO('ducker\nducker<2.0.2\n\n'))
+    os.makedirs(os.path.join(workdir, 'ducker'))
+
+    env = appenv.AppEnv(os.path.join(workdir, 'ducker'))
+    env.init()
+    assert not os.path.exists(env.appenv_dir)
+    env.update_lockfile()
+    env.prepare()
+    assert os.path.exists(env.appenv_dir)


### PR DESCRIPTION
This allows preparing the venv before running the app for the first time.

It allows installing the packages in a seperate layer (for better caching) when using AppEnv inside docker.

Original PR: https://github.com/flyingcircusio/appenv/pull/34