### PR TITLE
Add symlink to current appenv.

### DIFF
--- a/src/appenv.py
+++ b/src/appenv.py
@@ -333,7 +333,10 @@ class AppEnv(object):
                                b"".join(hash_content)).hexdigest()[:8]
         env_dir = os.path.join(self.appenv_dir, env_hash)
 
-        whitelist = set([env_dir, os.path.join(self.appenv_dir, "unclean")])
+        whitelist = set([
+            env_dir,
+            os.path.join(self.appenv_dir, "unclean"),
+            os.path.join(self.appenv_dir, 'current')])
         for path in glob.glob(
                 "{appenv_dir}/*".format(appenv_dir=self.appenv_dir)):
             if path not in whitelist:
@@ -369,6 +372,12 @@ class AppEnv(object):
 
             with open(os.path.join(env_dir, "appenv.ready"), "w") as f:
                 f.write("Ready or not, here I come, you can't hide\n")
+            current_path = os.path.join(self.appenv_dir, 'current')
+            try:
+                os.unlink(current_path)
+            except FileNotFoundError:
+                pass
+            os.symlink(env_dir, current_path)
 
         self.env_dir = env_dir
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -13,3 +13,16 @@ def test_prepare_creates_envdir(workdir, monkeypatch):
     env.update_lockfile()
     env.prepare()
     assert os.path.exists(env.appenv_dir)
+
+
+def test_prepare_creates_venv_symlink(workdir, monkeypatch):
+    # asserts that appenv_dir / "current" -> env_dir
+    monkeypatch.setattr('sys.stdin', io.StringIO('ducker\nducker<2.0.2\n\n'))
+    os.makedirs(os.path.join(workdir, 'ducker'))
+
+    env = appenv.AppEnv(os.path.join(workdir, 'ducker'))
+    env.init()
+    env.update_lockfile()
+    env.prepare()
+    assert os.path.islink(os.path.join(env.appenv_dir, "current"))
+    assert os.readlink(os.path.join(env.appenv_dir, "current")) == env.env_dir


### PR DESCRIPTION
This allows adding a stable path to the Python interpreter in IDEs like VS Code.