### PR TITLE
Fix ci: remove pkg_resource import, bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: 'v0.31.0'  # Use the sha / tag you want to point at
+-   repo: https://github.com/google/yapf
+    rev: 'v0.40.2'  # Use the sha / tag you want to point at
     hooks:
     -   id: yapf
         args: [-i, -p]
 -   repo: https://github.com/pycqa/flake8
-    rev: '4.0.1'  # pick a git hash / tag to point to
+    rev: '7.0.0'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8


### PR DESCRIPTION
`packaging` replaces `pkg_resources` for spec parsing according to https://setuptools.pypa.io/en/latest/pkg_resources.html

It should have the same avaliability since `pkg_resources` depends on `packaging`

Additionally, we are bumping the pre-commit dependencies since yapf is running into https://github.com/PyCQA/flake8/issues/1701