### PR TITLE
Revert "Fix ci: remove pkg_resource import, bump pre-commit dependencies"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.0.1
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/google/yapf
-    rev: 'v0.40.2'  # Use the sha / tag you want to point at
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: 'v0.31.0'  # Use the sha / tag you want to point at
     hooks:
     -   id: yapf
         args: [-i, -p]
 -   repo: https://github.com/pycqa/flake8
-    rev: '7.0.0'  # pick a git hash / tag to point to
+    rev: '4.0.1'  # pick a git hash / tag to point to
     hooks:
     -   id: flake8

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -444,7 +444,7 @@ class AppEnv(object):
         cmd("{tmpdir}/bin/python -m pip install -r requirements.txt".format(
             tmpdir=tmpdir))
 
-        # Hack because we might not have packaging, but the venv should
+        # Hack because we might not have pkg_resources, but the venv should
         tmp_paths = cmd(
             "{tmpdir}/bin/python -c"
             " 'import sys; print(\"\\n\".join(sys.path))'".format(
@@ -455,7 +455,7 @@ class AppEnv(object):
             if not line:
                 continue
             sys.path.append(line)
-        from packaging.requirements import Requirement
+        import pkg_resources
 
         extra_specs = []
         result = cmd(
@@ -466,8 +466,8 @@ class AppEnv(object):
             if line.strip().startswith('-e '):
                 # We'd like to pick up the original -e statement here.
                 continue
-            spec = Requirement(line)
-            pinned_versions[spec.name] = spec
+            spec = list(pkg_resources.parse_requirements(line))[0]
+            pinned_versions[spec.project_name] = spec
         requested_versions = {}
         with open('requirements.txt') as f:
             for line in f.readlines():
@@ -481,20 +481,20 @@ class AppEnv(object):
                 # filter comments, in particular # appenv-python-preferences
                 if line.strip().startswith('#'):
                     continue
-                spec = Requirement(line)
-                requested_versions[spec.name] = spec
+                spec = list(pkg_resources.parse_requirements(line))[0]
+                requested_versions[spec.project_name] = spec
 
         final_versions = {}
         for spec in requested_versions.values():
             # Pick versions with URLs to ensure we don't get the screwed up
             # results from pip freeze.
             if spec.url:
-                final_versions[spec.name] = spec
+                final_versions[spec.project_name] = spec
         for spec in pinned_versions.values():
             # Ignore versions we already picked
-            if spec.name in final_versions:
+            if spec.project_name in final_versions:
                 continue
-            final_versions[spec.name] = spec
+            final_versions[spec.project_name] = spec
         lines = [str(spec) for spec in final_versions.values()]
         lines.extend(extra_specs)
         lines.sort()


### PR DESCRIPTION
Reverts flyingcircusio/appenv#46

With #46 `appenv update-lockfile` fails, so I propose to revert it.

```
Update lockfile with with /opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/bin/python3.12.
If you want to use a different version, set it via
 `# appenv-python-preference:` in requirements.txt.
Updating lockfile
Creating venv ...
Ensuring pip ...
Installing packages ...
Traceback (most recent call last):
  File "/….batou/./appenv", line 533, in <module>
    main()
  File "/….batou/./appenv", line 525, in main
    appenv.meta()
  File "/….batou/./appenv", line 283, in meta
    args.func(args, remaining)
  File "/….batou/./appenv", line 458, in update_lockfile
    from packaging.requirements import Requirement
ModuleNotFoundError: No module named 'packaging'
```