### PR TITLE
Fix current symlink feature: link to env_hash instead of env_dir

### DIFF
--- a/src/appenv.py
+++ b/src/appenv.py
@@ -377,7 +377,7 @@ class AppEnv(object):
                 os.unlink(current_path)
             except FileNotFoundError:
                 pass
-            os.symlink(env_dir, current_path)
+            os.symlink(env_hash, current_path)
 
         self.env_dir = env_dir
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -25,4 +25,5 @@ def test_prepare_creates_venv_symlink(workdir, monkeypatch):
     env.update_lockfile()
     env.prepare()
     assert os.path.islink(os.path.join(env.appenv_dir, "current"))
-    assert os.readlink(os.path.join(env.appenv_dir, "current")) == env.env_dir
+    assert (os.path.realpath(os.path.join(
+        env.appenv_dir, "current")) == os.path.realpath(env.env_dir))


### PR DESCRIPTION
This one was caught by batou tests. Previously, the symlink was malformed and dangling

#45 introduced the current symlink feature