### PR TITLE
Remove distutils dep to fix broken ensurepip stdlib workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,39 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build-old-python:
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: ['3.6', '3.7']
 
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Runs a set of commands using the runners shell
+      - name: Setup
+        run: pip install tox
+
+      - name: Show environment
+        run: set
+
+      - name: Test
+        run: tox -e py -- -vv
+
+  build-new-python:
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -85,18 +85,17 @@ def ensure_venv(target):
         # This is trying to detect whether we're on a proper Python stdlib
         # or on a broken Debian. See various StackOverflow questions about
         # this.
-        import distutils.util  # noqa: F401 imported but unused
         import ensurepip  # noqa: F401 imported but unused
     except ImportError:
         # Okay, lets repair this, if we can. May need privilege escalation
         # at some point.
-        # We could do: apt-get -y -q install python3-distutils python3-venv
+        # We could do: apt-get -y -q install python3-venv
         # on some systems but it requires root and is specific to Debian.
         # I decided to go a more sledge hammer route.
 
         # XXX we can speed this up by storing this in ~/.appenv/overlay instead
         # of doing the download for every venv we manage
-        print("Activating broken distutils/ensurepip stdlib workaround ...")
+        print("Activating broken ensurepip stdlib workaround ...")
 
         tmp_base = tempfile.mkdtemp()
         try:
@@ -109,7 +108,7 @@ def ensure_venv(target):
 
             assert os.path.exists(
                 os.path.join(tmp_base, "Python-{}".format(version)))
-            for module in ["ensurepip", "distutils"]:
+            for module in ["ensurepip"]:
                 print(module)
                 shutil.copytree(
                     os.path.join(tmp_base, "Python-{}".format(version), "Lib",
@@ -119,7 +118,7 @@ def ensure_venv(target):
                                  "site-packages", module))
 
             # (always) prepend the site packages so we can actually have a
-            # fixed distutils installation.
+            # fixed installation.
             site_packages = os.path.abspath(
                 os.path.join(target, "lib", "python" + python_maj_min,
                              "site-packages"))


### PR DESCRIPTION
Should close #48 

I looked into why we import distutils anyways and only found this: https://github.com/flyingcircusio/appenv/commit/28dadf5f21bd25535dcec4c92852de3be749565e

This PR also activates newer python versions in CI, so that errors like that may be caught