### PR TITLE
python 3.12, setuptools and venv

### DIFF
--- a/src/appenv.py
+++ b/src/appenv.py
@@ -134,8 +134,7 @@ def ensure_venv(target):
     pip(target, ["install", "--upgrade", "pip"])
 
 
-def ensure_minimal_python():
-    current_python = os.path.realpath(sys.executable)
+def parse_preferences():
     preferences = None
     if os.path.exists('requirements.txt'):
         with open('requirements.txt') as f:
@@ -148,6 +147,12 @@ def ensure_minimal_python():
                 preferences = [x.strip() for x in preferences.split(',')]
                 preferences = list(filter(None, preferences))
                 break
+    return preferences
+
+
+def ensure_minimal_python():
+    current_python = os.path.realpath(sys.executable)
+    preferences = parse_preferences()
     if not preferences:
         # We have no preferences defined, use the current python.
         print("Update lockfile with with {}.".format(current_python))
@@ -201,20 +206,11 @@ def ensure_best_python(base):
         return
     import shutil
 
-    # use newest Python available if nothing else is requested
-    preferences = ['3.{}'.format(x) for x in reversed(range(4, 20))]
+    preferences = parse_preferences()
 
-    if os.path.exists('requirements.txt'):
-        with open('requirements.txt') as f:
-            for line in f:
-                # Expected format:
-                # # appenv-python-preference: 3.1,3.9,3.4
-                if not line.startswith("# appenv-python-preference: "):
-                    continue
-                preferences = line.split(':')[1]
-                preferences = [x.strip() for x in preferences.split(',')]
-                preferences = list(filter(None, preferences))
-                break
+    if preferences is None:
+        # use newest Python available if nothing else is requested
+        preferences = ['3.{}'.format(x) for x in reversed(range(4, 20))]
 
     current_python = os.path.realpath(sys.executable)
     for version in preferences:

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -155,7 +155,7 @@ def ensure_minimal_python():
     preferences = parse_preferences()
     if not preferences:
         # We have no preferences defined, use the current python.
-        print("Update lockfile with with {}.".format(current_python))
+        print("Updating lockfile with with {}.".format(current_python))
         print("If you want to use a different version, set it via")
         print(" `# appenv-python-preference:` in requirements.txt.")
         return

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -518,9 +518,10 @@ class AppEnv(object):
         ensure_minimal_python()
         preferences = parse_preferences()
         python312_mixed_setuptools_workaround = False
-        if preferences is not None and '3.12' in preferences and any(
-                f'3.{x}' in preferences for x in range(4, 12)):
-            python312_mixed_setuptools_workaround = True
+        if preferences is not None:
+            if any(f'3.{x}' in preferences for x in range(4, 12)):
+                if any(f'3.{x}' in preferences for x in range(12, 20)):
+                    python312_mixed_setuptools_workaround = True
         os.chdir(self.base)
         print("Updating lockfile")
         tmpdir = os.path.join(self.appenv_dir, "updatelock")

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -153,6 +153,13 @@ def ensure_minimal_python():
         print("Update lockfile with with {}.".format(current_python))
         print("If you want to use a different version, set it via")
         print(" `# appenv-python-preference:` in requirements.txt.")
+        if sys.version_info >= (3, 12):
+            print("You are using a Python version >= 3.12.")
+            print(
+                "Please specify a Python version in the requirements.txt file."
+            )
+            print("Lockfiles created with a Python version lower than 3.12")
+            print("may create a broken venv with a Python version >= 3.12.")
         return
 
     preferences.sort(key=lambda s: [int(u) for u in s.split('.')])

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -158,13 +158,6 @@ def ensure_minimal_python():
         print("Update lockfile with with {}.".format(current_python))
         print("If you want to use a different version, set it via")
         print(" `# appenv-python-preference:` in requirements.txt.")
-        if sys.version_info >= (3, 12):
-            print("You are using a Python version >= 3.12.")
-            print(
-                "Please specify a Python version in the requirements.txt file."
-            )
-            print("Lockfiles created with a Python version lower than 3.12")
-            print("may create a broken venv with a Python version >= 3.12.")
         return
 
     preferences.sort(key=lambda s: [int(u) for u in s.split('.')])
@@ -209,6 +202,13 @@ def ensure_best_python(base):
     preferences = parse_preferences()
 
     if preferences is None:
+        if sys.version_info >= (3, 12):
+            print("You are using a Python version >= 3.12.")
+            print(
+                "Please specify a Python version in the requirements.txt file."
+            )
+            print("Lockfiles created with a Python version lower than 3.12")
+            print("may create a broken venv with a Python version >= 3.12.")
         # use newest Python available if nothing else is requested
         preferences = ['3.{}'.format(x) for x in reversed(range(4, 20))]
 

--- a/src/appenv.py
+++ b/src/appenv.py
@@ -514,7 +514,7 @@ class AppEnv(object):
                 appenvdir=self.appenv_dir))
         cmd(["rm", "-rf", self.appenv_dir])
 
-    def update_lockfile(self, freeze_args=None, remaining=None):
+    def update_lockfile(self, args=None, remaining=None):
         ensure_minimal_python()
         preferences = parse_preferences()
         python312_mixed_setuptools_workaround = False


### PR DESCRIPTION

Since https://github.com/python/cpython/issues/95299 we need to ensure we have a setuptools ourselves.
They changed `pip freeze` behaviour in python 3.12 too: https://github.com/pypa/pip/pull/12032

~~This leaves us with 2 options:~~
1. ~~We could lock __all__ dependencies with `pip freeze --all` but:~~
    - ~~this would also lock `pip`, `wheel` to a specific version, which is a change in behaviour~~
    - ~~we would need to update the `requirements.lock` to update the version of `pip` used~~
2. ~~We could forbid projects with mixed python >= 3.12 and < 3.12 versions in their `appenv-python-preference` list~~
    - ~~this would prevent the issue from happening in the first place~~
    - ~~we would need to inform users about this change~~

~~To understand the second option better, it is important to know that `batou` only uses the first python version in the `appenv-python-preference` list that is actually installed on the system.~~


~~This means that if you have `3.12,3.11` as your `appenv-python-preference` and `3.12` is installed, `batou` will use `3.11` for lockfile preparation and `3.12` for venv creation. The resulting lockfile will not contain `setuptools` and `pip freeze` will not show `setuptools` either. This lockfile is incompatible with python 3.12, and once a user without `3.12` installed tries to create a venv, they will run into the issue described above.~~

~~Also, if you have `3.12,3.11` as your `appenv-python-preference` and `3.11` is installed, `batou` will use `3.11` for lockfile preparation and `3.11` for venv creation. The resulting lockfile will not contain `setuptools` and `pip freeze` will not show `setuptools` either. This does not immediately cause an issue, but once a user with `3.12` installed tries to create a venv, they will run into the issue described above.~~

This PR does `pip freeze --all --exclude pip` if both python >= 3.12 and < 3.12 are in the `appenv-python-preference` list. This mimics the behaviour of `pip freeze` after the change in python 3.12.
