### PR TITLE
Freeze all packages regardless of version

### DIFF
--- a/src/appenv.py
+++ b/src/appenv.py
@@ -516,12 +516,6 @@ class AppEnv(object):
 
     def update_lockfile(self, args=None, remaining=None):
         ensure_minimal_python()
-        preferences = parse_preferences()
-        python312_mixed_setuptools_workaround = False
-        if preferences is not None:
-            if any(f'3.{x}' in preferences for x in range(4, 12)):
-                if any(f'3.{x}' in preferences for x in range(12, 20)):
-                    python312_mixed_setuptools_workaround = True
         os.chdir(self.base)
         print("Updating lockfile")
         tmpdir = os.path.join(self.appenv_dir, "updatelock")
@@ -532,11 +526,9 @@ class AppEnv(object):
         pip(tmpdir, ["install", "-r", "requirements.txt"])
 
         extra_specs = []
-        pip_freeze_args = ["freeze"]
-        if python312_mixed_setuptools_workaround:
-            pip_freeze_args.extend(["--all", "--exclude", "pip"])
         result = pip(
-            tmpdir, pip_freeze_args, merge_stderr=False).decode('ascii')
+            tmpdir, ["freeze", "--all", "--exclude", "pip"],
+            merge_stderr=False).decode('ascii')
         # They changed this behaviour in https://github.com/pypa/pip/pull/12032
         pinned_versions = {}
         for line in result.splitlines():

--- a/tests/test_update_lockfile.py
+++ b/tests/test_update_lockfile.py
@@ -21,11 +21,10 @@ def test_init_and_create_lockfile(workdir, monkeypatch):
     assert os.path.exists(lockfile)
     with open(lockfile) as f:
         lockfile_content = f.read()
-    assert (lockfile_content == """\
+    assert """\
 # appenv-requirements-hash: ffa75c00de4879b41008d0e9f6b9953cf7d65bb5f5b85d1d049e783b2486614d
 ducker==2.0.1
-setuptools==40.6.2
-""")  # noqa
+setuptools==""" in lockfile_content  # noqa
 
 
 @pytest.mark.skipif(

--- a/tests/test_update_lockfile.py
+++ b/tests/test_update_lockfile.py
@@ -24,6 +24,7 @@ def test_init_and_create_lockfile(workdir, monkeypatch):
     assert (lockfile_content == """\
 # appenv-requirements-hash: ffa75c00de4879b41008d0e9f6b9953cf7d65bb5f5b85d1d049e783b2486614d
 ducker==2.0.1
+setuptools==40.6.2
 """)  # noqa
 
 

--- a/tests/test_update_lockfile.py
+++ b/tests/test_update_lockfile.py
@@ -23,8 +23,7 @@ def test_init_and_create_lockfile(workdir, monkeypatch):
         lockfile_content = f.read()
     assert """\
 # appenv-requirements-hash: ffa75c00de4879b41008d0e9f6b9953cf7d65bb5f5b85d1d049e783b2486614d
-ducker==2.0.1
-setuptools==""" in lockfile_content  # noqa
+ducker==2.0.1""" in lockfile_content  # noqa
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
https://github.com/flyingcircusio/batou/issues/466 uncovered a scenario where python<3.12 insistence to drop the setuptools requirements in `pip freeze` output also creates an inconsistent environment, due to setuptools version requirements of applications not being passed on.

We included a workaround for mixed python3.12 and python<3.12 environments, but the workaround is apparently applicable to all python<3.12 environments.

This PR changes the contents of some lockfiles ~~, which is the reason some tests fail for now.~~

